### PR TITLE
Refer to resource.json using the canonical root format

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -48,7 +48,7 @@
             "type": "object",
             "patternProperties": {
                 "^[a-zA-Z0-9]+$": {
-                    "$ref": "resource.json#/"
+                    "$ref": "resource.json#"
                 }
             },
             "additionalProperties": false


### PR DESCRIPTION
According to [RFC6901](https://tools.ietf.org/html/rfc6901#section-6) the JSON pointer (which JSON schema refers to) to the root object is identified by `#` not `#/`. Currently schema.json refers to resource.json's root as `resource.json#/`, which is rejected by e.g. VS Code's schema implementation.

This PR fixes that by referring to the resource root as `resource.json#`.